### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tonyzyt/7d753a5e-ed2b-4c2e-99eb-6de025aa56ba/06487bbc-ce53-4ab7-94ee-652e066164c3/_apis/work/boardbadge/6af6314b-4125-47a2-afb1-fb69cd01fd28)](https://dev.azure.com/tonyzyt/7d753a5e-ed2b-4c2e-99eb-6de025aa56ba/_boards/board/t/06487bbc-ce53-4ab7-94ee-652e066164c3/Microsoft.RequirementCategory)
 # FastAPI Tutorial
 This repo is for learning how to use FastAPI.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://dev.azure.com/tonyzyt/7d753a5e-ed2b-4c2e-99eb-6de025aa56ba/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.